### PR TITLE
Associate WebSocket connections with entities

### DIFF
--- a/server/internal/net/ws.go
+++ b/server/internal/net/ws.go
@@ -1,61 +1,68 @@
 package net
+
 import (
-"encoding/json"
-"log"
-"net/http"
+	"encoding/json"
+	"log"
+	"net/http"
 
-
-"github.com/gorilla/websocket"
-"mmo-ugc/server/internal/sim"
+	"github.com/gorilla/websocket"
+	"mmo-ugc/server/internal/sim"
 )
 
-
-var upgrader = websocket.Upgrader{ CheckOrigin: func(r *http.Request) bool { return true } }
-
+var upgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
 
 type Hub struct {
-world *sim.World
+	world *sim.World
 }
-
 
 func NewHub(w *sim.World) *Hub { return &Hub{world: w} }
 
-
 func (h *Hub) Run() { /* broadcast routing, auth hooks, etc. */ }
 
-
 type inbound struct {
-Type string `json:"type"`
-Data json.RawMessage `json:"data"`
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
 }
-
 
 type input struct {
-T int64 `json:"t"`
-AX float32 `json:"ax"`
-AY float32 `json:"ay"`
-AZ float32 `json:"az"`
+	T  int64   `json:"t"`
+	AX float32 `json:"ax"`
+	AY float32 `json:"ay"`
+	AZ float32 `json:"az"`
 }
-
 
 func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
-conn, err := upgrader.Upgrade(w, r, nil)
-if err != nil { log.Println("upgrade:", err); return }
-defer conn.Close()
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("upgrade:", err)
+		return
+	}
+	defer conn.Close()
 
-
-// TODO: auth (Nakama), создание EntityID
-for {
-_, msg, err := conn.ReadMessage()
-if err != nil { log.Println("read:", err); return }
-var in inbound
-if err := json.Unmarshal(msg, &in); err != nil { continue }
-if in.Type == "input" {
-var inp input
-if err := json.Unmarshal(in.Data, &inp); err == nil {
-// TODO: маппинг на конкретного EntityID
-// h.world.ApplyInput(sim.Input{T: inp.T, AX: inp.AX, AY: inp.AY, AZ: inp.AZ, EID: ...})
-}
-}
-}
+	// TODO: auth (Nakama)
+	eid := h.world.NewEntity()
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			log.Println("read:", err)
+			return
+		}
+		var in inbound
+		if err := json.Unmarshal(msg, &in); err != nil {
+			log.Println("unmarshal:", err)
+			return
+		}
+		if in.Type == "input" {
+			var inp input
+			if err := json.Unmarshal(in.Data, &inp); err != nil {
+				log.Println("input unmarshal:", err)
+				return
+			}
+			if !h.world.HasEntity(eid) {
+				log.Println("unknown entity:", eid)
+				return
+			}
+			h.world.ApplyInput(sim.Input{T: inp.T, AX: inp.AX, AY: inp.AY, AZ: inp.AZ, EID: eid})
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Assign each WebSocket connection a new `sim.Entity` upon connection
- Route input messages to the correct entity and close on errors or unknown entities
- Track entity IDs within the simulation world

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a4605dbba08331b8eaae2183dc74dd