### PR TITLE
feat: reconcile client prediction

### DIFF
--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -6,6 +6,8 @@ export class NetClient {
 private ws?: WebSocket
 private pending: Input[] = []
 private lastAck = 0
+private state = new Map<number, { x: number; y: number; z: number }>()
+private selfId?: number
 
 
 connect(url = 'ws://localhost:8080/ws'): Promise<void> {
@@ -16,14 +18,43 @@ this.ws.onerror = (e) => rej(e)
 this.ws.onmessage = (ev) => {
 const snap: Snapshot = JSON.parse(ev.data)
 this.lastAck = snap.t
-// TODO: reconcile локальное состояние
+// заменяем локальное состояние на серверный снапшот
+this.state.clear()
+for (const e of snap.entities) {
+this.state.set(e.id, { x: e.x, y: e.y, z: e.z })
+}
+if (this.selfId === undefined && snap.entities.length > 0) {
+this.selfId = snap.entities[0].id
+}
+// удаляем подтверждённые инпуты
+this.pending = this.pending.filter((p) => p.t > this.lastAck)
+// переигрываем оставшиеся инпуты поверх снапшота
+let prevT = this.lastAck
+for (const inp of this.pending) {
+const dt = (inp.t - prevT) / 1000
+this.applyInput(inp, dt)
+prevT = inp.t
+}
 }
 })
 }
 
 
 sendInput(inp: Input) {
+// применяем инпут локально для предсказания и сохраняем
+const prevT = this.pending.length ? this.pending[this.pending.length - 1].t : this.lastAck
+const dt = (inp.t - prevT) / 1000
+this.applyInput(inp, dt)
 this.pending.push(inp)
 this.ws?.send(JSON.stringify({ type: 'input', data: inp }))
+}
+
+private applyInput(inp: Input, dt: number) {
+if (!this.selfId) return
+const ent = this.state.get(this.selfId)
+if (!ent) return
+ent.x += inp.ax * dt
+ent.y += inp.ay * dt
+ent.z += inp.az * dt
 }
 }


### PR DESCRIPTION
## Summary
- maintain local snapshot state and player entity
- reapply unacknowledged inputs after server snapshots

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a46858862c8331bdeb2582ef707e11