### PR TITLE
feat: sync babylon mesh with transform

### DIFF
--- a/client/src/ecs/systems/babylonSync.ts
+++ b/client/src/ecs/systems/babylonSync.ts
@@ -1,0 +1,21 @@
+import { IWorld, defineQuery } from 'bitecs'
+import { Transform, Renderable } from '../components'
+import { getMesh } from '../../scene/meshFactory'
+
+export function babylonSyncSystem(world: IWorld) {
+  const q = defineQuery([Transform, Renderable])
+
+  return () => {
+    for (const eid of q(world)) {
+      const mesh = getMesh(Renderable.meshId[eid].toString())
+      if (mesh) {
+        mesh.position.set(
+          Transform.x[eid],
+          Transform.y[eid],
+          Transform.z[eid]
+        )
+      }
+    }
+    return world
+  }
+}


### PR DESCRIPTION
## Summary
- add Babylon sync system to update mesh positions from Transform and Renderable components

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47816cd74833184142379378b7e6e