### PR TITLE
Initialize ECS world and network client

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,15 +1,37 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { createScene } from './scene/engine'
+import { createWorld } from 'bitecs'
+import { NetClient } from './net/ws'
+import { babylonSyncSystem } from './ecs/systems/babylonSync'
+import { netApplySystem } from './ecs/systems/netApply'
 
+const world = createWorld()
+const net = new NetClient()
 
 function App() {
 const ref = React.useRef<HTMLCanvasElement>(null)
 React.useEffect(() => {
-if (ref.current) createScene(ref.current)
+if (ref.current) {
+const { engine, scene } = createScene(ref.current)
+const babylonSync = babylonSyncSystem(world)
+engine.runRenderLoop(() => {
+babylonSync()
+scene.render()
+})
+net.connect().then(() => {
+const ws = (net as any).ws as WebSocket
+const prev = ws.onmessage
+ws.onmessage = (ev) => {
+prev(ev)
+const snap = JSON.parse(ev.data)
+netApplySystem(world, { entities: snap.entities.map((e: any) => ({ id: e.id.toString(), x: e.x, y: e.y, z: e.z })) })
+}
+})
+}
 }, [])
 return <canvas ref={ref} style={{ width: '100vw', height: '100vh', display: 'block' }} />
 }
 
-
 createRoot(document.getElementById('root')!).render(<App />)
+


### PR DESCRIPTION
## Summary
- create ECS world and WebSocket NetClient
- apply server snapshots to ECS and sync Babylon meshes each frame

## Testing
- ⚠️ `npm test` (missing script)
- ⚠️ `npm run build` (fails: "scene" is not exported by "src/scene/engine.ts")

------
https://chatgpt.com/codex/tasks/task_e_68a479f1c1808331b35e67d7baeafba2