### PR TITLE
Send WASD acceleration input

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -28,6 +28,33 @@ const snap = JSON.parse(ev.data)
 netApplySystem(world, { entities: snap.entities.map((e: any) => ({ id: e.id.toString(), x: e.x, y: e.y, z: e.z })) })
 }
 })
+
+const keys = { w: false, a: false, s: false, d: false }
+const send = () => {
+const ax = (keys.d ? 1 : 0) - (keys.a ? 1 : 0)
+const az = (keys.w ? 1 : 0) - (keys.s ? 1 : 0)
+net.sendInput({ t: Date.now(), ax, ay: 0, az })
+}
+const down = (e: KeyboardEvent) => {
+const k = e.key.toLowerCase()
+if (k in keys && !keys[k as keyof typeof keys]) {
+keys[k as keyof typeof keys] = true
+send()
+}
+}
+const up = (e: KeyboardEvent) => {
+const k = e.key.toLowerCase()
+if (k in keys && keys[k as keyof typeof keys]) {
+keys[k as keyof typeof keys] = false
+send()
+}
+}
+window.addEventListener('keydown', down)
+window.addEventListener('keyup', up)
+return () => {
+window.removeEventListener('keydown', down)
+window.removeEventListener('keyup', up)
+}
 }
 }, [])
 return <canvas ref={ref} style={{ width: '100vw', height: '100vh', display: 'block' }} />


### PR DESCRIPTION
## Summary
- send acceleration vector input on WASD key events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: "scene" is not exported by "src/scene/engine.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68a47ba6f724833194454126060af0f8