### PR TITLE
feat: add snapshot interpolation

### DIFF
--- a/client/src/ecs/components.ts
+++ b/client/src/ecs/components.ts
@@ -5,3 +5,4 @@ export const Transform = defineComponent({ x: Types.f32, y: Types.f32, z: Types.
 export const Renderable = defineComponent({ meshId: Types.ui32 })
 export const Velocity = defineComponent({ x: Types.f32, y: Types.f32, z: Types.f32 })
 export const PlayerTag = defineComponent()
+export const RenderTransform = defineComponent({ x: Types.f32, y: Types.f32, z: Types.f32 })

--- a/client/src/ecs/systems/babylonSync.ts
+++ b/client/src/ecs/systems/babylonSync.ts
@@ -1,18 +1,18 @@
 import { IWorld, defineQuery } from 'bitecs'
-import { Transform, Renderable } from '../components'
+import { RenderTransform, Renderable } from '../components'
 import { getMesh } from '../../scene/meshFactory'
 
 export function babylonSyncSystem(world: IWorld) {
-  const q = defineQuery([Transform, Renderable])
+  const q = defineQuery([RenderTransform, Renderable])
 
   return () => {
     for (const eid of q(world)) {
       const mesh = getMesh(Renderable.meshId[eid].toString())
       if (mesh) {
         mesh.position.set(
-          Transform.x[eid],
-          Transform.y[eid],
-          Transform.z[eid]
+          RenderTransform.x[eid],
+          RenderTransform.y[eid],
+          RenderTransform.z[eid]
         )
       }
     }

--- a/client/src/ecs/systems/interpolate.ts
+++ b/client/src/ecs/systems/interpolate.ts
@@ -1,0 +1,35 @@
+import { IWorld } from 'bitecs'
+import { RenderTransform } from '../components'
+import { NetClient } from '../../net/ws'
+import { netIdToEid } from './netApply'
+
+export function interpolateSystem(world: IWorld, net: NetClient) {
+  return () => {
+    const snaps = net.getSnapshots()
+    if (snaps.length < 2) return world
+    const renderNow = Date.now() - net.renderDelay
+    let prev = snaps[0]
+    let next = snaps[snaps.length - 1]
+    for (let i = 0; i < snaps.length - 1; i++) {
+      const a = snaps[i]
+      const b = snaps[i + 1]
+      if (a.t <= renderNow && renderNow <= b.t) {
+        prev = a
+        next = b
+        break
+      }
+    }
+    const t = (renderNow - prev.t) / (next.t - prev.t || 1)
+    const prevMap = new Map(prev.entities.map(e => [String(e.id), e]))
+    for (const { id, x, y, z } of next.entities) {
+      const eid = netIdToEid.get(String(id))
+      if (eid === undefined) continue
+      const p = prevMap.get(String(id))
+      if (!p) continue
+      RenderTransform.x[eid] = p.x + (x - p.x) * t
+      RenderTransform.y[eid] = p.y + (y - p.y) * t
+      RenderTransform.z[eid] = p.z + (z - p.z) * t
+    }
+    return world
+  }
+}

--- a/client/src/ecs/systems/netApply.ts
+++ b/client/src/ecs/systems/netApply.ts
@@ -1,7 +1,7 @@
 import { IWorld, addEntity, addComponent, removeEntity } from 'bitecs'
-import { Transform, Renderable } from '../components'
+import { Transform, Renderable, RenderTransform } from '../components'
 
-const netIdToEid = new Map<string, number>()
+export const netIdToEid = new Map<string, number>()
 
 export function netApplySystem(
   world: IWorld,
@@ -14,11 +14,15 @@ export function netApplySystem(
       eid = addEntity(world)
       addComponent(world, Transform, eid)
       addComponent(world, Renderable, eid)
+      addComponent(world, RenderTransform, eid)
       netIdToEid.set(id, eid)
     }
     Transform.x[eid] = x
     Transform.y[eid] = y
     Transform.z[eid] = z
+    RenderTransform.x[eid] = x
+    RenderTransform.y[eid] = y
+    RenderTransform.z[eid] = z
     seen.add(id)
   }
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,6 +5,7 @@ import { createWorld } from 'bitecs'
 import { NetClient } from './net/ws'
 import { babylonSyncSystem } from './ecs/systems/babylonSync'
 import { netApplySystem } from './ecs/systems/netApply'
+import { interpolateSystem } from './ecs/systems/interpolate'
 
 const world = createWorld()
 const net = new NetClient()
@@ -15,7 +16,9 @@ React.useEffect(() => {
 if (ref.current) {
 const { engine, scene } = createScene(ref.current)
 const babylonSync = babylonSyncSystem(world)
+const interpolate = interpolateSystem(world, net)
 engine.runRenderLoop(() => {
+interpolate()
 babylonSync()
 scene.render()
 })


### PR DESCRIPTION
## Summary
- store recent snapshots and render delay in WebSocket client
- add RenderTransform component and interpolation system for smooth rendering
- sync Babylon meshes to interpolated transforms

## Testing
- `npm test --prefix client` *(fails: Missing script "test")*
- `npm run build --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68a485f4c1d4833181bea4b12ee7534a