### PR TITLE
Handle missing RenderTransform in Babylon sync system

### DIFF
--- a/client/src/ecs/systems/babylonSync.ts
+++ b/client/src/ecs/systems/babylonSync.ts
@@ -1,19 +1,27 @@
-import { IWorld, defineQuery } from 'bitecs'
-import { RenderTransform, Renderable } from '../components'
+import { IWorld, defineQuery, hasComponent } from 'bitecs'
+import { RenderTransform, Renderable, Transform } from '../components'
 import { getMesh } from '../../scene/meshFactory'
 
 export function babylonSyncSystem(world: IWorld) {
-  const q = defineQuery([RenderTransform, Renderable])
+  const q = defineQuery([Renderable])
 
   return () => {
     for (const eid of q(world)) {
       const mesh = getMesh(Renderable.meshId[eid].toString())
       if (mesh) {
-        mesh.position.set(
-          RenderTransform.x[eid],
-          RenderTransform.y[eid],
-          RenderTransform.z[eid]
-        )
+        if (hasComponent(world, RenderTransform, eid)) {
+          mesh.position.set(
+            RenderTransform.x[eid],
+            RenderTransform.y[eid],
+            RenderTransform.z[eid]
+          )
+        } else if (hasComponent(world, Transform, eid)) {
+          mesh.position.set(
+            Transform.x[eid],
+            Transform.y[eid],
+            Transform.z[eid]
+          )
+        }
       }
     }
     return world


### PR DESCRIPTION
## Summary
- Query renderable entities and sync mesh positions from `RenderTransform`
- Fall back to `Transform` positions when `RenderTransform` is absent, avoiding interpolation glitches

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a48bafc224833188cc58150cc1ceb5