### PR TITLE
Limit client extrapolation to server time

### DIFF
--- a/client/src/ecs/systems/interpolate.ts
+++ b/client/src/ecs/systems/interpolate.ts
@@ -7,9 +7,24 @@ export function interpolateSystem(world: IWorld, net: NetClient) {
   return () => {
     const snaps = net.getSnapshots()
     if (snaps.length < 2) return world
-    const renderNow = Date.now() - net.renderDelay
-    let prev = snaps[0]
-    let next = snaps[snaps.length - 1]
+    const serverNow = Date.now() - net.serverTimeDiff
+    const renderNow = serverNow - net.renderDelay
+    const last = snaps[snaps.length - 1]
+    const prevLast = snaps[snaps.length - 2]
+    const step = last.t - prevLast.t
+    const max = last.t + step * 2
+    if (renderNow > max) {
+      for (const { id, x, y, z } of last.entities) {
+        const eid = netIdToEid.get(String(id))
+        if (eid === undefined) continue
+        RenderTransform.x[eid] = x
+        RenderTransform.y[eid] = y
+        RenderTransform.z[eid] = z
+      }
+      return world
+    }
+    let prev = prevLast
+    let next = last
     for (let i = 0; i < snaps.length - 1; i++) {
       const a = snaps[i]
       const b = snaps[i + 1]

--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -12,6 +12,7 @@ private selfId?: string
 private snapshots: Snapshot[] = []
 private readonly maxSnapshots = 32
 renderDelay = 100
+serverTimeDiff = 0
 
 
 connect(url = 'ws://localhost:8080/ws'): Promise<void> {
@@ -30,6 +31,7 @@ return new Promise((res, rej) => {
         this.ws.onerror = (e) => rej(e)
         this.ws.onmessage = (ev) => {
           const snap: Snapshot = JSON.parse(ev.data)
+          this.serverTimeDiff = Date.now() - snap.t
           this.snapshots.push(snap)
           if (this.snapshots.length > this.maxSnapshots) {
             this.snapshots.shift()


### PR DESCRIPTION
## Summary
- Track server time from snapshots and expose offset
- Clamp client interpolation to at most two ticks ahead and freeze position when exceeded

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4dff9d3ac83319bebb83d2c378eab