### PR TITLE
refactor: separate entity sync and clean render transforms

### DIFF
--- a/client/src/ecs/systems/netApply.ts
+++ b/client/src/ecs/systems/netApply.ts
@@ -1,35 +1,51 @@
-import { IWorld, addEntity, addComponent, removeEntity } from 'bitecs'
+import { IWorld, addEntity, addComponent, removeEntity, removeComponent } from 'bitecs'
 import { Transform, Renderable, RenderTransform } from '../components'
+import { createMeshFor, removeMesh } from '../../scene/meshFactory'
 
 export const netIdToEid = new Map<string, number>()
 
-export function netApplySystem(
+export function syncEntities(
   world: IWorld,
   snapshot: { entities: Array<{ id: string; x: number; y: number; z: number }> }
 ) {
   const seen = new Set<string>()
-  for (const { id, x, y, z } of snapshot.entities) {
+  for (const { id } of snapshot.entities) {
     let eid = netIdToEid.get(id)
     if (eid === undefined) {
       eid = addEntity(world)
       addComponent(world, Transform, eid)
       addComponent(world, Renderable, eid)
       addComponent(world, RenderTransform, eid)
+      Renderable.meshId[eid] = Number(id)
+      createMeshFor(id)
       netIdToEid.set(id, eid)
     }
+    seen.add(id)
+  }
+
+  for (const [id, eid] of netIdToEid) {
+    if (!seen.has(id)) {
+      removeComponent(world, RenderTransform, eid)
+      removeComponent(world, Renderable, eid)
+      removeMesh(id)
+      removeEntity(world, eid)
+      netIdToEid.delete(id)
+    }
+  }
+}
+
+export function netApplySystem(
+  world: IWorld,
+  snapshot: { entities: Array<{ id: string; x: number; y: number; z: number }> }
+) {
+  for (const { id, x, y, z } of snapshot.entities) {
+    const eid = netIdToEid.get(id)
+    if (eid === undefined) continue
     Transform.x[eid] = x
     Transform.y[eid] = y
     Transform.z[eid] = z
     RenderTransform.x[eid] = x
     RenderTransform.y[eid] = y
     RenderTransform.z[eid] = z
-    seen.add(id)
-  }
-
-  for (const [id, eid] of netIdToEid) {
-    if (!seen.has(id)) {
-      removeEntity(world, eid)
-      netIdToEid.delete(id)
-    }
   }
 }

--- a/client/src/scene/meshFactory.ts
+++ b/client/src/scene/meshFactory.ts
@@ -6,12 +6,20 @@ const meshes = new Map<string, Mesh>()
 
 
 export function createMeshFor(id: string): Mesh {
-const mesh = MeshBuilder.CreateBox(id, {}, scene)
-meshes.set(id, mesh)
-return mesh
+  const mesh = MeshBuilder.CreateBox(id, {}, scene)
+  meshes.set(id, mesh)
+  return mesh
 }
-
 
 export function getMesh(id: string): Mesh | undefined {
-return meshes.get(id)
+  return meshes.get(id)
 }
+
+export function removeMesh(id: string) {
+  const mesh = meshes.get(id)
+  if (mesh) {
+    mesh.dispose()
+    meshes.delete(id)
+  }
+}
+


### PR DESCRIPTION
## Summary
- extract entity creation/removal to `syncEntities`
- dispose meshes when removing entities to prevent lingering renders
- update main snapshot handler to run both sync and transform updates

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e178bb54833182d8f44e9e62309a