### PR TITLE
Use predicted local state for rendering self

### DIFF
--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -68,16 +68,23 @@ const dt = (inp.t - prevT) / 1000
     this.ws.send(JSON.stringify({ type: 'input', data: inp }))
 }
 
-private applyInput(inp: Input, dt: number) {
-if (!this.selfId) return
-const ent = this.state.get(this.selfId)
-if (!ent) return
-ent.x += inp.ax * dt
-ent.y += inp.ay * dt
-ent.z += inp.az * dt
-}
+  private applyInput(inp: Input, dt: number) {
+  if (!this.selfId) return
+  const ent = this.state.get(this.selfId)
+  if (!ent) return
+  ent.x += inp.ax * dt
+  ent.y += inp.ay * dt
+  ent.z += inp.az * dt
+  }
 
-getSnapshots() {
-return this.snapshots
-}
+  getSelfState() {
+  if (!this.selfId) return
+  const ent = this.state.get(this.selfId)
+  if (!ent) return
+  return { id: this.selfId, x: ent.x, y: ent.y, z: ent.z }
+  }
+
+  getSnapshots() {
+  return this.snapshots
+  }
 }


### PR DESCRIPTION
## Summary
- expose predicted self position on NetClient
- bypass interpolation for self and apply predicted state to RenderTransform

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a56a43db248331b69da1ba45511a21