### PR TITLE
refactor: centralize world bounds

### DIFF
--- a/server/internal/sim/bounds.go
+++ b/server/internal/sim/bounds.go
@@ -1,0 +1,11 @@
+package sim
+
+// world bounds
+const (
+	worldMinX = -100.0
+	worldMaxX = 100.0
+	worldMinY = 0.0
+	worldMaxY = 100.0
+	worldMinZ = -100.0
+	worldMaxZ = 100.0
+)

--- a/server/internal/sim/world.go
+++ b/server/internal/sim/world.go
@@ -7,16 +7,6 @@ import (
 	"time"
 )
 
-// world bounds
-const (
-	worldMinX = -100.0
-	worldMaxX = 100.0
-	worldMinY = 0.0
-	worldMaxY = 100.0
-	worldMinZ = -100.0
-	worldMaxZ = 100.0
-)
-
 type EntityID int64
 
 type Entity struct {


### PR DESCRIPTION
## Summary
- centralize world boundary constants
- update simulation to use shared bounds

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a78e14d10c833189237fae1a7015dc