### PR TITLE
Use ticker-driven accumulator in world

### DIFF
--- a/server/internal/sim/world.go
+++ b/server/internal/sim/world.go
@@ -57,18 +57,25 @@ func NewWorld() *World {
 }
 
 func (w *World) Run(dt time.Duration) {
+	ticker := time.NewTicker(dt)
+	defer ticker.Stop()
+
 	last := time.Now()
 	var acc time.Duration
 	stepDt := float32(dt.Seconds())
-	for {
-		acc += time.Since(last)
-		last = time.Now()
+	for range ticker.C {
+		now := time.Now()
+		acc += now.Sub(last)
+		last = now
+
+		steps := 0
 		for acc >= dt {
 			w.step(stepDt)
 			acc -= dt
+			steps++
 		}
-		if acc < dt {
-			time.Sleep(dt - acc)
+		if steps > 1 {
+			log.Printf("world.Run tick overrun: processed %d steps", steps)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- replace manual sleep loop in `World.Run` with ticker-driven accumulator to hold fixed dt
- execute multiple simulation steps when accumulator exceeds dt and log overruns for tuning

## Testing
- `cd server && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a78f30d95c8331b82bd7b7661f32fb