### PR TITLE
Initialize Rapier and await loading

### DIFF
--- a/client/src/physics/rapier.ts
+++ b/client/src/physics/rapier.ts
@@ -1,8 +1,13 @@
-import init, * as RAPIER from '@dimforge/rapier3d-compat'
-
+import RAPIER, { init } from '@dimforge/rapier3d-compat'
 
 let ready: Promise<typeof RAPIER> | null = null
+
 export function loadRapier() {
-if (!ready) ready = init().then(() => RAPIER)
-return ready
+  if (!ready) {
+    ready = (async () => {
+      await init()
+      return RAPIER
+    })()
+  }
+  return ready
 }

--- a/client/src/physics/world.ts
+++ b/client/src/physics/world.ts
@@ -1,6 +1,7 @@
 import { loadRapier } from './rapier'
 
-const worldReady = loadRapier().then(RAPIER => {
+const worldReady = (async () => {
+  const RAPIER = await loadRapier()
   const world = new RAPIER.World({ x: 0, y: 0, z: 0 })
   const minX = -100, maxX = 100
   const minY = 0, maxY = 100
@@ -36,9 +37,8 @@ const worldReady = loadRapier().then(RAPIER => {
     world.createRigidBody(RAPIER.RigidBodyDesc.fixed())
   )
   return { RAPIER, world }
-})
+})()
 
 export function getPhysicsWorld() {
   return worldReady
 }
-


### PR DESCRIPTION
## Summary
- switch to default RAPIER import with named init
- ensure loadRapier initializes and returns namespace
- await Rapier loading in physics world setup

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8169832788331a68366016f57cf6b