### PR TITLE
feat(scene): add meshes and lights

### DIFF
--- a/client/src/scene/engine.ts
+++ b/client/src/scene/engine.ts
@@ -1,4 +1,13 @@
-import { Engine, Scene, Vector3, HemisphericLight, ArcRotateCamera, MeshBuilder } from '@babylonjs/core'
+import {
+  Engine,
+  Scene,
+  Vector3,
+  HemisphericLight,
+  ArcRotateCamera,
+  MeshBuilder,
+  PointLight,
+  DirectionalLight,
+} from '@babylonjs/core'
 
 
 export let engine: Engine
@@ -14,12 +23,25 @@ scene = new Scene(engine)
 camera = new ArcRotateCamera('cam', Math.PI / 2, Math.PI / 3, 8, Vector3.Zero(), scene)
 camera.attachControl(canvas, true)
 
-
 new HemisphericLight('h', new Vector3(0, 1, 0), scene)
+
+const point = new PointLight('p', new Vector3(5, 5, -5), scene)
+point.intensity = 0.7
+
+const dir = new DirectionalLight('d', new Vector3(-1, -2, -1), scene)
+dir.position = new Vector3(10, 10, 10)
+
 MeshBuilder.CreateGround('ground', { width: 20, height: 20 }, scene)
 
+const box = MeshBuilder.CreateBox('box', {}, scene)
+box.position.y = 0.5
 
-engine.runRenderLoop(() => scene.render())
+const sphere = MeshBuilder.CreateSphere('sphere', { diameter: 1.5 }, scene)
+sphere.position = new Vector3(2, 1.5, 0)
+
+const cyl = MeshBuilder.CreateCylinder('cyl', { height: 2 }, scene)
+cyl.position = new Vector3(-2, 1, 0)
+
 window.addEventListener('resize', () => engine.resize())
 
 

--- a/client/src/scene/meshFactory.ts
+++ b/client/src/scene/meshFactory.ts
@@ -4,9 +4,21 @@ import { scene } from './engine'
 
 const meshes = new Map<string, Mesh>()
 
+export interface MeshConfig {
+  kind?: 'box' | 'sphere'
+  size?: number
+  diameter?: number
+}
 
-export function createMeshFor(id: string): Mesh {
-  const mesh = MeshBuilder.CreateBox(id, {}, scene)
+export function createMeshFor(id: string, cfg: MeshConfig = {}): Mesh {
+  let mesh: Mesh
+  switch (cfg.kind) {
+    case 'sphere':
+      mesh = MeshBuilder.CreateSphere(id, { diameter: cfg.diameter }, scene)
+      break
+    default:
+      mesh = MeshBuilder.CreateBox(id, { size: cfg.size }, scene)
+  }
   meshes.set(id, mesh)
   return mesh
 }


### PR DESCRIPTION
## Summary
- enrich Babylon scene with point and directional lights
- add demo meshes (box, sphere, cylinder) for testing
- expand mesh factory with configurable primitive generation

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a81b72b2dc833192337b1474f2f826