### PR TITLE
Throttle client input messages

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -39,10 +39,16 @@ const prev = ws.onmessage
 })
 
 const keys = { w: false, a: false, s: false, d: false }
+let lastAx = 0
+let lastAz = 0
 const send = () => {
 const ax = (keys.d ? 1 : 0) - (keys.a ? 1 : 0)
 const az = (keys.w ? 1 : 0) - (keys.s ? 1 : 0)
+if (ax !== lastAx || az !== lastAz) {
+lastAx = ax
+lastAz = az
 net.sendInput({ t: Date.now(), ax, ay: 0, az })
+}
 }
 const down = (e: KeyboardEvent) => {
 const k = e.key.toLowerCase()


### PR DESCRIPTION
## Summary
- avoid sending duplicate input over the network by tracking last WASD state

## Testing
- `npm run build`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a8212a0cb883319d230e42f9687a3b