### PR TITLE
Add DebugHUD to display network state

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -14,6 +14,40 @@ net.onLocalUpdate((state) => {
   netApplySystem(world, { entities: [state] })
 })
 
+function DebugHUD() {
+  const [state, setState] = React.useState({
+    self: net.getSelfState(),
+    connected: net.connected,
+  })
+
+  React.useEffect(() => {
+    let frame: number
+    const update = () => {
+      setState({ self: net.getSelfState(), connected: net.connected })
+      frame = requestAnimationFrame(update)
+    }
+    frame = requestAnimationFrame(update)
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        color: 'white',
+        background: 'rgba(0,0,0,0.5)',
+        padding: 4,
+        fontFamily: 'monospace',
+      }}
+    >
+      <div>connected: {String(state.connected)}</div>
+      <div>self: {state.self ? JSON.stringify(state.self) : 'null'}</div>
+    </div>
+  )
+}
+
 function App() {
 const ref = React.useRef<HTMLCanvasElement>(null)
 React.useEffect(() => {
@@ -72,7 +106,12 @@ window.removeEventListener('keyup', up)
 }
 }
 }, [])
-return <canvas ref={ref} style={{ width: '100vw', height: '100vh', display: 'block' }} />
+return (
+  <>
+    <canvas ref={ref} style={{ width: '100vw', height: '100vh', display: 'block' }} />
+    <DebugHUD />
+  </>
+)
 }
 
 createRoot(document.getElementById('root')!).render(<App />)

--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -6,8 +6,8 @@ export type Snapshot = { t: number; entities: Array<{ id: number; x:number; y:nu
 
 
 export class NetClient {
-private ws?: WebSocket
-private connected = false
+  private ws?: WebSocket
+  connected = false
 private pending: Input[] = []
 private lastAck = 0
 private state = new Map<string, { x: number; y: number; z: number }>()


### PR DESCRIPTION
## Summary
- expose NetClient.connected
- add DebugHUD overlay showing connection and self state

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8237acf588331b0e8efc7d5485eb7