### PR TITLE
Fix WebSocket URL domain for dev

### DIFF
--- a/client/.env.local
+++ b/client/.env.local
@@ -1,1 +1,1 @@
-VITE_WS_URL=wss://fuzzy-couscous-7v7494vx9ppv2r44p.app.github.dev/ws
+VITE_WS_URL=wss://8080-fuzzy-couscous-7v7494vx9ppv2r44p.app.github.dev/ws


### PR DESCRIPTION
## Summary
- fix VITE_WS_URL to include the 8080 codespace prefix

## Testing
- `npm run dev` *(fails: Port 5173 is already in use)*

------
https://chatgpt.com/codex/tasks/task_e_68a84ade54e48331ba8001521d5a0a19