### PR TITLE
Log WebSocket URL for debugging

### DIFF
--- a/client/.env.local
+++ b/client/.env.local
@@ -1,1 +1,2 @@
+# WebSocket endpoint for Codespace
 VITE_WS_URL=wss://8080-fuzzy-couscous-7v7494vx9ppv2r44p.app.github.dev/ws

--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -53,6 +53,7 @@ serverTimeDiff = 0
           : location.host
         return `${proto}://${host}/ws`
       })()
+      console.log(wsUrl)
       this.ws = new WebSocket(wsUrl)
       this.ws.onopen = () => {
             this.connected = true


### PR DESCRIPTION
## Summary
- document codespace WebSocket endpoint in `.env.local`
- log resolved WebSocket URL before opening connection

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a85a2df4448331a67355c87c55b900