### PR TITLE
Avoid GitHub dev host prefix in websocket client

### DIFF
--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -48,9 +48,7 @@ serverTimeDiff = 0
         const envUrl = (import.meta as any).env?.VITE_WS_URL
         if (envUrl) return envUrl as string
         const proto = location.protocol === 'https:' ? 'wss' : 'ws'
-        const host = location.hostname.endsWith('app.github.dev')
-          ? `8080-${location.hostname}`
-          : location.host
+        const host = location.host
         return `${proto}://${host}/ws`
       })()
       console.log(wsUrl)


### PR DESCRIPTION
## Summary
- simplify websocket host detection so GitHub dev domains use VITE_WS_URL or location.host without `8080-` prefix

## Testing
- `npm --prefix client run build`
- `npm --prefix client test` *(fails: Missing script: "test")*
- `(cd server && go test ./...)`
- `npx wscat -s test -c ws://localhost:8080/ws`


------
https://chatgpt.com/codex/tasks/task_e_68a8d0cbcdc08331b3635aa835d6b5d0