### PR TITLE
fix(ws): adjust host for codespace wss

### DIFF
--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -48,7 +48,9 @@ serverTimeDiff = 0
         const envUrl = (import.meta as any).env?.VITE_WS_URL
         if (envUrl) return envUrl as string
         const proto = location.protocol === 'https:' ? 'wss' : 'ws'
-        const host = location.host
+        const host = location.hostname.endsWith('app.github.dev')
+          ? `8080-${location.hostname}`
+          : location.host
         return `${proto}://${host}/ws`
       })()
       console.log(wsUrl)


### PR DESCRIPTION
## Summary
- adjust WebSocket host to handle `app.github.dev` domains

## Testing
- `npm --prefix client run build`
- `timeout 5s npm --prefix client run dev`
- `timeout 2s npx wscat -c ws://localhost:8080/ws?token=abc`

------
https://chatgpt.com/codex/tasks/task_e_68a8d68b6ef083319870cbc8dc1b29c3