### PR TITLE
Allow configuring WebSocket token via env or query

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for the client
+# VITE_WS_URL=ws://localhost:3000/ws
+
+# Optional token for WebSocket authentication
+# VITE_WS_TOKEN=your-token

--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -53,8 +53,11 @@ serverTimeDiff = 0
           : location.host
         return `${proto}://${host}/ws`
       })()
+      const token =
+        (import.meta as any).env?.VITE_WS_TOKEN ??
+        new URLSearchParams(location.search).get('token')
       console.log(wsUrl)
-      this.ws = new WebSocket(wsUrl)
+      this.ws = token ? new WebSocket(wsUrl, token) : new WebSocket(wsUrl)
       this.ws.onopen = () => {
             this.connected = true
             for (const inp of this.pending) {


### PR DESCRIPTION
## Summary
- Read WebSocket auth token from `VITE_WS_TOKEN` env or URL query
- Pass token to WebSocket constructor when connecting
- Document `VITE_WS_TOKEN` in client `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8dca902588331a3f5eb69661af1d1