### PR TITLE
docs: document codespace ws url

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,16 @@ wait
 4. `make client` — открыть `http://localhost:5173`.
 5. В `client/src/net/ws.ts` укажи адрес WS сервера при необходимости.
 
+### Codespaces WebSocket URL
+
+When running in GitHub Codespaces the WebSocket host **must** use the port prefix format:
+
+```
+VITE_WS_URL=wss://8080-<codespace>.app.github.dev/ws
+```
+
+Open the **Ports** tab in your Codespace and ensure port `8080` is set to **Public** before connecting.
+
 ---
 
 ## 7) Куда расширять дальше (чек-лист)

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,5 +1,6 @@
 # Example environment variables for the client
-# VITE_WS_URL=ws://localhost:3000/ws
+# Codespaces: VITE_WS_URL=wss://8080-<codespace>.app.github.dev/ws
+# Local: VITE_WS_URL=ws://localhost:8080/ws
 
 # Optional token for WebSocket authentication
 # VITE_WS_TOKEN=your-token

--- a/client/.env.local
+++ b/client/.env.local
@@ -1,2 +1,2 @@
 # WebSocket endpoint for Codespace
-VITE_WS_URL=wss://8080-fuzzy-couscous-7v7494vx9ppv2r44p.app.github.dev/ws
+VITE_WS_URL=wss://8080-<codespace>.app.github.dev/ws

--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -43,7 +43,7 @@ serverTimeDiff = 0
 
   connect(url?: string): Promise<void> {
     return new Promise((res, rej) => {
-      const wsUrl = (() => {
+      let wsUrl = (() => {
         if (url) return url
         const envUrl = (import.meta as any).env?.VITE_WS_URL
         if (envUrl) return envUrl as string
@@ -53,6 +53,19 @@ serverTimeDiff = 0
           : location.host
         return `${proto}://${host}/ws`
       })()
+
+      if (location.hostname.endsWith('app.github.dev')) {
+        try {
+          const parsed = new URL(wsUrl)
+          const match = parsed.hostname.match(/^(.*)-8080\.app\.github\.dev$/)
+          if (match) {
+            parsed.hostname = `8080-${match[1]}.app.github.dev`
+            wsUrl = parsed.toString()
+          }
+        } catch {
+          /* ignore */
+        }
+      }
       const token =
         (import.meta as any).env?.VITE_WS_TOKEN ??
         new URLSearchParams(location.search).get('token')


### PR DESCRIPTION
## Summary
- document Codespaces `VITE_WS_URL` format and port requirements
- normalize suffix Codespaces hosts in WebSocket client

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8e01ff72c83318a2d032e66ee2688