### PR TITLE
chore: add websocket token env variable

### DIFF
--- a/client/.env.local
+++ b/client/.env.local
@@ -1,2 +1,5 @@
 # WebSocket endpoint for Codespace
 VITE_WS_URL=wss://8080-<codespace>.app.github.dev/ws
+
+# Optional token for WebSocket authentication
+VITE_WS_TOKEN=dev-token


### PR DESCRIPTION
## Summary
- include optional VITE_WS_TOKEN in client env for websocket auth

## Testing
- `cd client && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8e5e057d083318d17278a1c82795c