### PR TITLE
Log WebSocket close and error details

### DIFF
--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -78,10 +78,11 @@ serverTimeDiff = 0
             }
             res()
         }
-        this.ws.onclose = () => {
+        this.ws.onclose = (e) => {
+            console.log(e.code, e.reason)
             this.connected = false
         }
-        this.ws.onerror = (e) => rej(e)
+        this.ws.onerror = (e) => { console.error(e); rej(e) }
         this.ws.onmessage = (ev) => {
           const snap: Snapshot = JSON.parse(ev.data)
           this.serverTimeDiff = Date.now() - snap.t


### PR DESCRIPTION
## Summary
- log close code and reason in client WebSocket
- log WebSocket errors in the console

## Testing
- `npm --prefix client run build`
- `(cd server && go test ./...)`
- `NODE_PATH=$(npm root -g) node -e "const WebSocket=require('ws'); const ws=new WebSocket('ws://localhost:8080/ws'); ws.on('error', err=>console.error('error', err.message)); ws.on('close', (code, reason)=>console.log('close', code, reason.toString()));"`

------
https://chatgpt.com/codex/tasks/task_e_68a8e6fe605c8331a25978c09be8a8e2