### PR TITLE
Log unauthorized requests in WebSocket handler

### DIFF
--- a/server/internal/net/ws.go
+++ b/server/internal/net/ws.go
@@ -39,6 +39,7 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 	}
 	userID, err := auth.ValidateToken(token)
 	if err != nil {
+		log.Println("unauthorized", r.RemoteAddr)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
## Summary
- log remote address when auth token validation fails in WebSocket handler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a9799ebb588331868b6a35c3293458