### PR TITLE
Handle dev token and clarify unauthorized client errors

### DIFF
--- a/client/src/net/ws.ts
+++ b/client/src/net/ws.ts
@@ -88,6 +88,7 @@ serverTimeDiff = 0
         this.ws.onclose = (e) => {
             if (e.code === 1006) {
               console.error('соединение отклонено; проверьте токен или доступность сервера')
+              console.error('401 Unauthorized: проверьте, что VITE_WS_TOKEN совпадает с серверным')
             }
             console.log(e.code, e.reason)
             this.connected = false

--- a/server/internal/net/ws.go
+++ b/server/internal/net/ws.go
@@ -38,7 +38,9 @@ func (h *Hub) HandleWS(w http.ResponseWriter, r *http.Request) {
 		token = r.URL.Query().Get("token")
 	}
 	userID, err := auth.ValidateToken(token)
-	if err != nil {
+	if token == "dev" {
+		userID = "dev"
+	} else if err != nil {
 		log.Println("unauthorized", r.RemoteAddr)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return


### PR DESCRIPTION
## Summary
- accept special "dev" token for websocket connections
- warn client about mismatched VITE_WS_TOKEN on 1006 close codes

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a980e59c3c83319e1e662a0d890fb4